### PR TITLE
Fix failing test

### DIFF
--- a/utils/st2-check-register-pack-resources
+++ b/utils/st2-check-register-pack-resources
@@ -35,7 +35,7 @@ PACK_PATH=$2
 
 source ${SCRIPT_PATH}/common.sh
 
-PACK_NAME=$(basename ${PACK_PATH})
+PACK_NAME=$(basename ${PACK_PATH} | cut -d "-" -f 1)
 
 ST2_REPO_PATH="st2/"
 ST2_COMPONENTS=$(get_st2_components)


### PR DESCRIPTION
I updated PACK_NAME extraction. It's dependent on the repository name and fails after updating name from arteria-packs to arteria, since the repository name still is arteria-packs.